### PR TITLE
Add Docker support and remote tracker connection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["python", "-m", "tracker_host", "-c", "config.yaml", "-v"]

--- a/config.docker.yaml
+++ b/config.docker.yaml
@@ -1,0 +1,35 @@
+# Docker configuration for tracker-host
+# Connects to synthetic-adsb and retina-tracker services by container name
+
+output_dir: "/app/output"
+poll_interval_sec: 0.5
+status_interval_sec: 10.0
+
+retry:
+  max_attempts: 5
+  backoff_base_sec: 1
+  extended_outage_sec: 30
+  health_check_interval_sec: 10
+
+api_forward:
+  enabled: false
+  url: ""
+
+trackers:
+  - name: "synthetic-rx1"
+    detection_url: "http://synthetic-adsb-test:49158/api/detection"
+    tcp_host: "retina-tracker-test"
+    tcp_port: 30100
+    spawn_tracker: false
+
+  - name: "synthetic-rx2"
+    detection_url: "http://synthetic-adsb-test:49159/api/detection"
+    tcp_host: "retina-tracker-test"
+    tcp_port: 30100
+    spawn_tracker: false
+
+  - name: "synthetic-rx3"
+    detection_url: "http://synthetic-adsb-test:49160/api/detection"
+    tcp_host: "retina-tracker-test"
+    tcp_port: 30100
+    spawn_tracker: false

--- a/config.test.yaml
+++ b/config.test.yaml
@@ -1,0 +1,38 @@
+# Test configuration for tracker-host
+# Connects to synthetic-adsb for integration testing
+
+# Global settings
+output_dir: "./test_output"
+poll_interval_sec: 0.5
+status_interval_sec: 10.0
+
+# Path to retina-tracker (relative to tracker-host directory)
+retina_tracker_path: "../retina-tracker"
+
+# Retry/resilience settings (faster for testing)
+retry:
+  max_attempts: 3
+  backoff_base_sec: 1
+  extended_outage_sec: 30
+  health_check_interval_sec: 10
+
+# API forwarding disabled for testing
+api_forward:
+  enabled: false
+  url: ""
+
+# Tracker instances - connected to synthetic-adsb radar endpoints
+trackers:
+  - name: "synthetic-rx1"
+    detection_url: "http://localhost:49158/api/detection"
+    tcp_port: 30100
+    # Use test-specific tracker config
+    # tracker_config: "./tracker-config.test.yaml"
+
+  - name: "synthetic-rx2"
+    detection_url: "http://localhost:49159/api/detection"
+    tcp_port: 30101
+
+  - name: "synthetic-rx3"
+    detection_url: "http://localhost:49160/api/detection"
+    tcp_port: 30102

--- a/tracker_host/config.py
+++ b/tracker_host/config.py
@@ -33,6 +33,8 @@ class TrackerConfig:
     name: str
     detection_url: str
     tcp_port: int
+    tcp_host: str = "127.0.0.1"
+    spawn_tracker: bool = True
     tracker_config: Optional[str] = None
     api_forward: Optional[ApiForwardConfig] = None
 
@@ -96,6 +98,8 @@ def _parse_config(raw: dict) -> Config:
                 name=t["name"],
                 detection_url=t["detection_url"],
                 tcp_port=t["tcp_port"],
+                tcp_host=t.get("tcp_host", "127.0.0.1"),
+                spawn_tracker=t.get("spawn_tracker", True),
                 tracker_config=t.get("tracker_config"),
                 api_forward=tracker_api,
             )

--- a/tracker_host/instance.py
+++ b/tracker_host/instance.py
@@ -10,7 +10,7 @@ from typing import Optional
 
 import aiohttp
 
-from .config import ApiForwardConfig, Config, RetryConfig, TrackerConfig
+from .config import Config, TrackerConfig
 from .fetcher import DetectionFetcher, ExtendedOutageError
 from .output_handler import OutputHandler
 
@@ -85,8 +85,9 @@ class TrackerInstance:
 
         logger.info(f"Starting tracker instance: {self.name}")
 
-        # Start the retina-tracker subprocess
-        await self._start_tracker_process()
+        # Start the retina-tracker subprocess (unless connecting to remote)
+        if self.config.spawn_tracker:
+            await self._start_tracker_process()
 
         # Connect to tracker via TCP
         await self._connect_to_tracker()
@@ -94,10 +95,10 @@ class TrackerInstance:
         self.state = InstanceState.RUNNING
 
         # Start background tasks
-        self._tasks = [
-            asyncio.create_task(self._fetch_loop(), name=f"{self.name}-fetch"),
-            asyncio.create_task(self._output_loop(), name=f"{self.name}-output"),
-        ]
+        tasks = [asyncio.create_task(self._fetch_loop(), name=f"{self.name}-fetch")]
+        if self.config.spawn_tracker:
+            tasks.append(asyncio.create_task(self._output_loop(), name=f"{self.name}-output"))
+        self._tasks = tasks
 
     async def stop(self) -> None:
         """Stop the tracker instance."""
@@ -122,8 +123,9 @@ class TrackerInstance:
         # Close TCP connection
         await self._close_tcp()
 
-        # Stop subprocess
-        await self._stop_tracker_process()
+        # Stop subprocess (if we spawned it)
+        if self.config.spawn_tracker:
+            await self._stop_tracker_process()
 
         # Close handlers
         await self.fetcher.close()
@@ -197,25 +199,25 @@ class TrackerInstance:
 
     async def _connect_to_tracker(self) -> None:
         """Connect to the tracker's TCP port."""
-        max_retries = 10
-        retry_delay = 0.5
+        max_retries = 30 if not self.config.spawn_tracker else 10
+        retry_delay = 1.0 if not self.config.spawn_tracker else 0.5
+        host = self.config.tcp_host
 
         for attempt in range(max_retries):
             try:
                 self._tcp_reader, self._tcp_writer = await asyncio.open_connection(
-                    "127.0.0.1", self.config.tcp_port
+                    host, self.config.tcp_port
                 )
-                logger.info(f"Connected to tracker TCP port {self.config.tcp_port}")
+                logger.info(f"Connected to tracker at {host}:{self.config.tcp_port}")
                 return
             except (ConnectionRefusedError, OSError) as e:
                 if attempt < max_retries - 1:
-                    logger.debug(
-                        f"TCP connection attempt {attempt + 1} failed: {e}, retrying..."
-                    )
+                    port = self.config.tcp_port
+                    logger.debug(f"TCP attempt {attempt + 1} to {host}:{port} failed: {e}, retrying...")
                     await asyncio.sleep(retry_delay)
                 else:
                     raise RuntimeError(
-                        f"Failed to connect to tracker after {max_retries} attempts"
+                        f"Failed to connect to tracker at {host}:{self.config.tcp_port} after {max_retries} attempts"
                     )
 
     async def _close_tcp(self) -> None:
@@ -242,9 +244,10 @@ class TrackerInstance:
                 logger.error(f"Extended outage for {self.name}, stopping tracker")
                 self.state = InstanceState.RECONNECTING
 
-                # Stop the tracker subprocess
+                # Stop the tracker subprocess (if we spawned it)
                 await self._close_tcp()
-                await self._stop_tracker_process()
+                if self.config.spawn_tracker:
+                    await self._stop_tracker_process()
 
                 # Clear metrics since tracker is down
                 self.output_handler.metrics.clear()
@@ -254,7 +257,8 @@ class TrackerInstance:
 
                 # Restart
                 logger.info(f"Restarting tracker for {self.name}")
-                await self._start_tracker_process()
+                if self.config.spawn_tracker:
+                    await self._start_tracker_process()
                 await self._connect_to_tracker()
                 self.state = InstanceState.RUNNING
 


### PR DESCRIPTION
## Summary

Adds Docker support and the ability to connect to remote retina-tracker instances.

### Changes

- **Dockerfile**: Containerized deployment of tracker-host
- **New config options**:
  - `tcp_host`: Connect to tracker at specified host (default: 127.0.0.1)
  - `spawn_tracker`: Set to `false` to connect to external tracker instead of spawning subprocess
- **config.docker.yaml**: Pre-configured for docker-compose with container hostnames
- **config.test.yaml**: Local testing config for synthetic-adsb

### Why

This enables running the full pipeline in Docker:
```
synthetic-adsb → tracker-host → retina-tracker
```

Required for end-to-end integration testing of anomaly detection (Issue #6 in retina-tracker).

### Example config for remote tracker

```yaml
trackers:
  - name: "radar1"
    detection_url: "http://synthetic-adsb:49158/api/detection"
    tcp_host: "retina-tracker"  # Connect to container by name
    tcp_port: 30100
    spawn_tracker: false        # Don't spawn subprocess
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)